### PR TITLE
Fix conflict with Sinatra::JSON

### DIFF
--- a/lib/sinatra/github_webhooks.rb
+++ b/lib/sinatra/github_webhooks.rb
@@ -13,7 +13,7 @@ module Sinatra
     end
 
     def payload
-      JSON.parse(payload_body)
+      ::JSON.parse(payload_body)
     end
 
     private


### PR DESCRIPTION
When [Sinatra::JSON](http://sinatrarb.com/contrib/json) is loaded, `payload` refers to the wrong JSON constant, resulting in an exception like this:

~~~ruby
undefined method `parse' for Sinatra::JSON:Module (NoMethodError)
    /Users/hongli/.rvm/gems/ruby-2.4.4/gems/sinatra-github_webhooks-0.2.0/lib/sinatra/github_webhooks.rb:14:in `payload'
~~~

This pull request fixes this by referring to the top-level JSON constant.